### PR TITLE
🔧 Refactor order handling: rename getOrderByCode to getOrderById, upd…

### DIFF
--- a/apps/backend/src/controllers/order.controller.ts
+++ b/apps/backend/src/controllers/order.controller.ts
@@ -22,7 +22,7 @@ export class OrderController {
         res.status(200).json(orders);
     });
 
-    getOrderByCode = asyncHandler(async (
+    getOrderById = asyncHandler(async (
         req: TypedRequest<{params: OrderIdParam}>, 
         res: Response, 
     ): Promise<void> => {

--- a/apps/backend/src/routes/v1/order.route.ts
+++ b/apps/backend/src/routes/v1/order.route.ts
@@ -503,7 +503,7 @@ const router = Router();
  *           type: array
  *           items:
  *             type: string
- *             enum: [CONFIRMED, COMPLETED, PICKED_UP]
+ *             enum: [PENDING, CONFIRMED, COMPLETED, PICKED_UP]
  *         style: form
  *         explode: true
  *         example: 
@@ -700,7 +700,7 @@ router.get(
     validateRequest({
         params: orderIdParamSchema
     }),
-    orderController.getOrderByCode
+    orderController.getOrderById
 )
 
 /**
@@ -732,7 +732,7 @@ router.get(
  *       - Subtotal is automatically calculated from food items: Σ(quantity × price)
  *       - If confirm data is provided: Total = Subtotal + surcharge - discount
  *       
- *       **Note:** Returns lightweight response without food details. Use GET /{code} to retrieve full order details.
+ *       **Note:** Returns lightweight response without food details. Use GET /{id} to retrieve full order details.
  *       
  *       **Authentication:** Requires bearer token (admin or operator role).
  *     tags:

--- a/apps/backend/src/schemas/order.ts
+++ b/apps/backend/src/schemas/order.ts
@@ -51,7 +51,7 @@ export const patchOrderSchema = z.object({
 })
 
 export const orderIdParamSchema = z.object({
-    id: z.number().int().min(0)
+    id: z.string().transform((val) => parseInt(val, 10)).pipe(z.number().int().min(1))
 })
 
 export type ConfirmedOrder = z.infer<typeof confirmedOrderSchema>

--- a/apps/backend/src/schemas/params.ts
+++ b/apps/backend/src/schemas/params.ts
@@ -8,13 +8,5 @@ export const cuidParamSchema = z.object({
     id: z.string().cuid()
 });
 
-export const pageParamSchema = z.object({
-    page: z.string().transform((val) => parseInt(val, 10)).pipe(z.number().int().min(0))
-});
-
-export const searchValueParamSchema = z.object({
-    value: z.string().min(1)
-});
-
 export type CUIDParam = z.infer<typeof cuidParamSchema>
 export type NumberIdParam = z.infer<typeof idParamSchema>

--- a/apps/backend/src/services/order.service.ts
+++ b/apps/backend/src/services/order.service.ts
@@ -261,7 +261,10 @@ export class OrderService {
         }
 
         // cashier only event
-        this.events[0].broadcastEvent(newOrder, "new-order")
+        if(!confirm){
+            this.events[0].broadcastEvent(newOrder, "new-order")
+        }
+        
         return newOrder;
     }
 


### PR DESCRIPTION
This pull request updates the order retrieval logic to use order IDs instead of codes, improves validation for order ID parameters, and clarifies API documentation regarding order status and endpoints. It also includes a small logic fix for event broadcasting in the order service.

**Order retrieval and routing changes:**
- Renamed the controller method from `getOrderByCode` to `getOrderById` and updated all route references to use the new method, ensuring consistency in how orders are fetched by ID. [[1]](diffhunk://#diff-76a2fbb8bb09d0700d7a11cc8d24430b0c9cbaa2e23db0be2279b44bc991b4a7L25-R25) [[2]](diffhunk://#diff-37fd4f5fd90332226d25d482541536abe78bc2333992e3306c311b3456ede2edL703-R703)
- Updated API documentation to reference `/orders/{id}` instead of `/orders/{code}` for retrieving full order details, reflecting the new ID-based approach.

**Validation and schema updates:**
- Improved `orderIdParamSchema` to strictly parse string IDs into integers and require IDs to be positive integers (min 1), strengthening request validation.

**API documentation enhancements:**
- Added `PENDING` to the allowed list of order status values in the OpenAPI specification, making the API documentation more accurate.

**Order service logic:**
- Fixed event broadcasting in `OrderService` to only broadcast the "new-order" event if the order is not confirmed, preventing unnecessary events.…ate route and schema for consistency, and enhance order ID validation