### PR TITLE
Feat/cash registers and printers

### DIFF
--- a/apps/frontend/src/app/[locale]/admin/food/_components/foodDialog.tsx
+++ b/apps/frontend/src/app/[locale]/admin/food/_components/foodDialog.tsx
@@ -235,7 +235,7 @@ function FoodForm({ form, onSubmit, food, categories }: FoodFormProps) {
                             <FormLabel>{t('formFields.category.title')}</FormLabel>
                             <Select
                                 onValueChange={(value) => field.onChange(parseInt(value))}
-                                defaultValue={field.value.toString()}
+                                defaultValue={field?.value?.toString()}
                             >
                                 <FormControl>
                                     <SelectTrigger>

--- a/apps/frontend/src/app/[locale]/admin/food/_components/foodDialog.tsx
+++ b/apps/frontend/src/app/[locale]/admin/food/_components/foodDialog.tsx
@@ -11,14 +11,6 @@ import {
     DialogClose
 } from "@/components/ui/dialog"
 
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@/components/ui/select"
-
 import { Button } from "@/components/ui/button"
 import { Food } from "@/types/food"
 import { Pencil, PlusCircle } from "lucide-react"
@@ -175,7 +167,8 @@ interface FoodFormProps {
 function FoodForm({ form, onSubmit, food, categories }: FoodFormProps) {
 
     const t = useTranslations('Food');
-
+    console.log(categories)
+    
     return (
         <Form {...form}>
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
@@ -223,35 +216,6 @@ function FoodForm({ form, onSubmit, food, categories }: FoodFormProps) {
                             <FormDescription>
                                 {t('formFields.price.description')}
                             </FormDescription>
-                            <FormMessage />
-                        </FormItem>
-                    )}
-                />
-                <FormField
-                    control={form.control}
-                    name="categoryId"
-                    render={({ field }) => (
-                        <FormItem>
-                            <FormLabel>{t('formFields.category.title')}</FormLabel>
-                            <Select
-                                onValueChange={(value) => field.onChange(parseInt(value))}
-                                defaultValue={field?.value?.toString()}
-                            >
-                                <FormControl>
-                                    <SelectTrigger>
-                                        <SelectValue placeholder={t('formFields.category.placeholder')} />
-                                    </SelectTrigger>
-                                </FormControl>
-                                <SelectContent>
-                                    {
-                                        categories.map(category =>
-                                            <SelectItem key={category.id} value={category.id.toString()}>
-                                                {category.name}
-                                            </SelectItem>
-                                        )
-                                    }
-                                </SelectContent>
-                            </Select>
                             <FormMessage />
                         </FormItem>
                     )}

--- a/apps/frontend/src/app/[locale]/admin/users/_components/userDialog.tsx
+++ b/apps/frontend/src/app/[locale]/admin/users/_components/userDialog.tsx
@@ -9,14 +9,6 @@ import {
     DialogClose
 } from "@/components/ui/dialog"
 
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@/components/ui/select"
-
 import { Button } from "@/components/ui/button"
 import { PlusCircle } from "lucide-react"
 import { useForm } from "react-hook-form"
@@ -97,6 +89,7 @@ interface UserFormProps {
 }
 
 function UserForm({ form, onSubmit, roles }: UserFormProps) {
+    console.log(roles)
     const t = useTranslations('User')
     return (
         <Form {...form}>
@@ -126,35 +119,6 @@ function UserForm({ form, onSubmit, roles }: UserFormProps) {
                             <FormControl>
                                 <Input type="password" placeholder={t('dialog.password.placeholder')} {...field} />
                             </FormControl>
-                            <FormMessage />
-                        </FormItem>
-                    )}
-                />
-                <FormField
-                    control={form.control}
-                    name="roleId"
-                    render={({ field }) => (
-                        <FormItem>
-                            <FormLabel>{t('formFields.role')}</FormLabel>
-                            <Select
-                                onValueChange={(value) => field.onChange(parseInt(value))}
-                                defaultValue={field.value.toString()}
-                            >
-                                <FormControl>
-                                    <SelectTrigger>
-                                        <SelectValue />
-                                    </SelectTrigger>
-                                </FormControl>
-                                <SelectContent>
-                                    {
-                                        roles.map(role =>
-                                            <SelectItem key={role.id} value={role.id.toString()}>
-                                                {role.name}
-                                            </SelectItem>
-                                        )
-                                    }
-                                </SelectContent>
-                            </Select>
                             <FormMessage />
                         </FormItem>
                     )}


### PR DESCRIPTION
This pull request simplifies the `FoodForm` component in `foodDialog.tsx` by removing the category selection field and its related imports. Additionally, a console log for the `categories` prop has been added, likely for debugging purposes.

Form field removal and UI simplification:

* Removed the entire form field for selecting a food category (`categoryId`), including all related UI and logic, from the `FoodForm` component. ([apps/frontend/src/app/[locale]/admin/food/_components/foodDialog.tsxL230-L258](diffhunk://#diff-13a4efc56a64806e83d5983dd79f461f2fc38a3099fd384b911a395094457f21L230-L258))
* Removed all unused imports related to the `Select` component and its subcomponents from `@/components/ui/select`. ([apps/frontend/src/app/[locale]/admin/food/_components/foodDialog.tsxL14-L21](diffhunk://#diff-13a4efc56a64806e83d5983dd79f461f2fc38a3099fd384b911a395094457f21L14-L21))

Debugging:

* Added a `console.log(categories)` statement to log the `categories` prop in the `FoodForm` component, likely for debugging. ([apps/frontend/src/app/[locale]/admin/food/_components/foodDialog.tsxR170](diffhunk://#diff-13a4efc56a64806e83d5983dd79f461f2fc38a3099fd384b911a395094457f21R170))