### PR TITLE
🧑‍💼 Added roles routes

### DIFF
--- a/apps/backend/src/controllers/role.controller.ts
+++ b/apps/backend/src/controllers/role.controller.ts
@@ -18,7 +18,7 @@ export class RoleController {
     });
 
     getRoleById = asyncHandler(async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-        const id = req.params.id;
+        const id = req.params.id as string;
         const role = await this.roleService.getRoleById(id);
         if (!role) {
             res.status(404).json({ message: "Role not found" });
@@ -27,6 +27,7 @@ export class RoleController {
         res.status(200).json(role);
     })
 
+    /*
     createRole = asyncHandler(async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         const { name } = req.body;
         const role = await this.roleService.createRole(name)
@@ -34,15 +35,16 @@ export class RoleController {
     });
 
     updateRole = asyncHandler(async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-        const id = req.params.id;
+        const id = req.params.id as string;
         const { name } = req.body;
         const role = await this.roleService.updateRole(id, name)
         res.status(200).json(role);
     });
 
     deleteRole = asyncHandler(async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-        const id = req.params.id;
+        const id = req.params.id as string;
         await this.roleService.deleteRole(id);
         res.status(204).send();
     });
+    */
 }

--- a/apps/backend/src/docs/swagger.ts
+++ b/apps/backend/src/docs/swagger.ts
@@ -21,11 +21,11 @@ const options: SwaggerOptions = {
             {
                 name: 'Users',
                 description: 'User management'
-            }/*,
+            },
             {
                 name: 'Roles',
                 description: 'Role management'
-            }*/,
+            },
             {
                 name: 'Categories',
                 description: 'Category management'

--- a/apps/backend/src/routes/v1/index.ts
+++ b/apps/backend/src/routes/v1/index.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import categoryRoutes from "./category.route";
 import foodRoutes from "./food.routes";
 import orderRoutes from "./order.route";
-//import roleRoutes from "./role.route";
+import roleRoutes from "./role.route";
 //import statsRoutes from "./stats.route";
 import userRoutes from "./user.route";
 import ingredientRoutes from "./ingredient.route"
@@ -16,7 +16,7 @@ router.use("/categories", categoryRoutes);
 router.use("/foods", foodRoutes);
 router.use("/ingredients", ingredientRoutes);
 router.use("/orders", orderRoutes);
-//router.use("/roles", roleRoutes);
+router.use("/roles", roleRoutes);
 //router.use("/stats", statsRoutes);
 router.use("/users", userRoutes);
 router.use("/cash-registers", cashRegisterRoutes);

--- a/apps/backend/src/routes/v1/role.route.ts
+++ b/apps/backend/src/routes/v1/role.route.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { authenticate } from "@/middlewares/authenticate";
 
 import { validateRequest } from "@/middlewares/validateRequest";
-import { CreateRoleSchema, idParamSchema } from "@/schemas";
+import { cuidParamSchema } from "@/schemas";
 
 import { RoleController } from "@/controllers/role.controller";
 import { RoleService } from "@/services/role.service";
@@ -11,12 +11,83 @@ const roleController = new RoleController(new RoleService());
 
 const router = Router();
 
+/**
+ * @openapi
+ * /v1/roles:
+ *   get:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: Get all roles
+ *     tags:
+ *       - Roles
+ *     responses:
+ *       200:
+ *         description: List of roles
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: string
+ *                     example: "cjld2cyuq0000t3rmniod1foy"
+ *                   name:
+ *                     type: string
+ *                     example: "admin"
+ *       404:
+ *         description: Roles not found
+ */
 router.get(
     "/",
     authenticate(["admin", "operator"]),
     roleController.getRoles
 );
 
+/**
+ * @openapi
+ * /v1/roles/{id}:
+ *   get:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: Get a role by ID
+ *     tags:
+ *       - Roles
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         description: ID of the role
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Role found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: string
+ *                   example: "cjld2cyuq0000t3rmniod1foy"
+ *                 name:
+ *                   type: string
+ *                   example: "admin"
+ *       404:
+ *         description: Role not found
+ */
+router.get(
+    "/:id",
+    authenticate(["admin", "operator"]),
+    validateRequest({
+        params: cuidParamSchema
+    }),
+    roleController.getRoleById
+);
+
+/*
 router.post(
     "/",
     authenticate(["admin"]),
@@ -43,13 +114,5 @@ router.delete(
     }),
     roleController.deleteRole
 );
-router.get(
-    "/:id",
-    authenticate(["admin", "operator"]),
-    validateRequest({
-        params: idParamSchema
-    }),
-    roleController.getRoleById
-);
-
+*/
 export default router;


### PR DESCRIPTION
This pull request re-enables and updates the roles API endpoints in the backend, improves OpenAPI documentation for the roles routes, and updates parameter validation. It also restores the `/roles` route in the main router and makes related type and schema adjustments.

**API Endpoint Updates:**

* Re-enabled the `/roles` routes by uncommenting their import and usage in `index.ts`, allowing role-related API endpoints to be accessible again. [[1]](diffhunk://#diff-6e79ac6d6b3049612e541847e7980ec7076025c54d87988fdd5c064a3343b55aL5-R5) [[2]](diffhunk://#diff-6e79ac6d6b3049612e541847e7980ec7076025c54d87988fdd5c064a3343b55aL19-R19)

**OpenAPI Documentation Improvements:**

* Added detailed OpenAPI documentation for the `GET /v1/roles` and `GET /v1/roles/{id}` endpoints in `role.route.ts`, specifying security, parameters, and response schemas.

**Validation and Typing Adjustments:**

* Updated parameter validation for the `GET /v1/roles/{id}` endpoint to use `cuidParamSchema` instead of `idParamSchema`, ensuring correct ID format validation. [[1]](diffhunk://#diff-6d4303b21cdf029de44a6508174e4404e08dfc0d6774e7c6a74a4baaa0087e61L5-R5) [[2]](diffhunk://#diff-6d4303b21cdf029de44a6508174e4404e08dfc0d6774e7c6a74a4baaa0087e61R14-R90)
* Explicitly cast `req.params.id` to `string` in `RoleController` methods for type safety. [[1]](diffhunk://#diff-69328843eac41c02827d091cb1d605ac394ecf1fb299c059d7171623d94bddf3L21-R21) [[2]](diffhunk://#diff-69328843eac41c02827d091cb1d605ac394ecf1fb299c059d7171623d94bddf3R30-R49)

**Swagger Documentation Fixes:**

* Fixed the roles tag in the Swagger options to ensure the "Roles" tag appears in the generated API docs.

**Temporary Disabling of Mutating Endpoints:**

* Commented out the `POST`, `PUT`, and `DELETE` role endpoints in both the controller and router to temporarily disable role creation, update, and deletion functionality. [[1]](diffhunk://#diff-6d4303b21cdf029de44a6508174e4404e08dfc0d6774e7c6a74a4baaa0087e61R14-R90) [[2]](diffhunk://#diff-6d4303b21cdf029de44a6508174e4404e08dfc0d6774e7c6a74a4baaa0087e61L46-R117) [[3]](diffhunk://#diff-69328843eac41c02827d091cb1d605ac394ecf1fb299c059d7171623d94bddf3R30-R49)