### PR TITLE
📃 Fixed category and printer Id patch, updated the docs

### DIFF
--- a/apps/backend/src/routes/v1/category.route.ts
+++ b/apps/backend/src/routes/v1/category.route.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 
 //middlewares
 import { authenticate } from "@/middlewares/authenticate";
-import { CreateCategorySchema, cuidParamSchema, GetCategoriesQuerySchema, PatchCategorySchema, UpdateFoodSchema } from "@/schemas";
+import { CreateCategorySchema, cuidParamSchema, GetCategoriesQuerySchema, PatchCategorySchema, UpdateCategorySchema } from "@/schemas";
 import { validateRequest } from "@/middlewares/validateRequest";
 //service and controller
 import { CategoryService } from "@/services/category.service";
@@ -181,6 +181,11 @@ router.post(
  *     security:
  *       - bearerAuth: []
  *     summary: Update a category
+ *     description: |
+ *       Update a category by ID.
+ *       
+ *       - Changing the **available** field will also update the availability of all associated foods.
+ *       - Changing the **printerId** field will also update the printer of all associated foods. Setting it to `null` will remove the printer association from the category and all its foods.
  *     tags:
  *       - Categories
  *     parameters:
@@ -212,7 +217,7 @@ router.put(
     authenticate(["admin"]),
     validateRequest({
         params: cuidParamSchema,
-        body: UpdateFoodSchema
+        body: UpdateCategorySchema
     }),
     categoryController.updateCategory
 );
@@ -223,8 +228,12 @@ router.put(
  *   patch:
  *     security:
  *       - bearerAuth: []
- *     summary: Update availability status of a category
- *     description: Update the availability of a category. Note that changing the availability of a category will also update the availability of all associated foods.
+ *     summary: Partially update a category
+ *     description: |
+ *       Partially update a category by ID.
+ *       
+ *       - Changing the **available** field will also update the availability of all associated foods.
+ *       - Changing the **printerId** field will also update the printer of all associated foods. Setting it to `null` will remove the printer association from the category and all its foods.
  *     tags:
  *       - Categories
  *     parameters:

--- a/apps/backend/src/routes/v1/food.routes.ts
+++ b/apps/backend/src/routes/v1/food.routes.ts
@@ -296,9 +296,14 @@ router.put(
  *                 type: boolean
  *                 description: New availability status
  *                 example: false
+ *               printerId:
+ *                 type: string
+ *                 nullable: true
+ *                 description: CUID of the printer associated with this food item. Set to `null` to remove the printer association.
+ *                 example: "clxyz987654321fedcba"
  *     responses:
  *       200:
- *         description: Food availability updated successfully
+ *         description: Food item updated successfully
  *         content:
  *           application/json:
  *             schema:

--- a/apps/backend/src/schemas/category.ts
+++ b/apps/backend/src/schemas/category.ts
@@ -21,7 +21,7 @@ export const UpdateCategorySchema = z.object({
 
 export const PatchCategorySchema = z.object({
     available: z.boolean().optional(),
-    printerId: CategoryBase.printerId.optional()
+    printerId: CategoryBase.printerId.optional().nullable()
 }).refine(data => Object.keys(data).length > 0, {
     message: "At least one field must be provided"
 })

--- a/apps/backend/src/schemas/food.ts
+++ b/apps/backend/src/schemas/food.ts
@@ -39,7 +39,7 @@ export const UpdateFoodSchema = z.object({
 
 export const PatchFoodSchema = z.object({
     available: z.boolean().optional(),
-    printerId: z.string().cuid()
+    printerId: z.string().cuid().nullable().optional()
 }).refine(data => Object.keys(data).length > 0, {
     message: "At least one field must be provided"
 })

--- a/apps/backend/src/services/category.service.ts
+++ b/apps/backend/src/services/category.service.ts
@@ -85,11 +85,25 @@ export class CategoryService {
     }
 
     async updateCategory(id: string, category: UpdateCategoryInput) {
-        return await prisma.category.update({
-            where: {
-                id
-            },
-            data: category
+        return await prisma.$transaction(async (tx) => {
+            const updateCategory = await tx.category.update({
+                where: {
+                    id
+                },
+                data: category
+            })
+
+            const foodUpdate: Prisma.FoodUpdateManyArgs = {
+                where: {
+                    categoryId: id,
+                },
+                data: {
+                    available: category.available,
+                    printerId: category.printerId
+                }
+            }
+            await tx.food.updateMany(foodUpdate)
+            return updateCategory;
         })
     }
 
@@ -104,10 +118,11 @@ export class CategoryService {
 
             const foodUpdate: Prisma.FoodUpdateManyArgs = {
                 where: {
-                    categoryId: id
+                    categoryId: id,
                 },
                 data: {
-                    available: patchCategory.available
+                    available: patchCategory.available,
+                    printerId: patchCategory.printerId
                 }
             }
 

--- a/apps/backend/src/services/food.service.ts
+++ b/apps/backend/src/services/food.service.ts
@@ -173,6 +173,7 @@ export class FoodService {
                 id
             },
             data: {
+                printerId: food.printerId,
                 available: food.available
             }
         })


### PR DESCRIPTION
This pull request introduces several improvements and clarifications to the backend API, focusing on real-time event documentation, category and food update behaviors, and schema consistency. The most significant changes are grouped below.

### Real-time Event API Documentation Enhancements

* Expanded and clarified the documentation for the `/events` SSE API, introducing three distinct channels (`cashier`, `display`, `printer`) with detailed event payload examples for each, and updated connection/client usage instructions.
* Updated OpenAPI specs to reflect the new channels and event types, including improved example responses and error messages for invalid channel values. [[1]](diffhunk://#diff-ba76cb2f45ce09372a3cac29a1bfbd30fa1b4c9b146805dfe99c8e6d7c04b1f0L78-R178) [[2]](diffhunk://#diff-ba76cb2f45ce09372a3cac29a1bfbd30fa1b4c9b146805dfe99c8e6d7c04b1f0L98-R206) [[3]](diffhunk://#diff-ba76cb2f45ce09372a3cac29a1bfbd30fa1b4c9b146805dfe99c8e6d7c04b1f0L125-R230)

### Category and Food Update Semantics

* Clarified in the OpenAPI documentation for category update endpoints (`PUT` and `PATCH`) that changing the `available` or `printerId` fields on a category will also update these fields for all associated foods. Setting `printerId` to `null` removes the printer association from both the category and its foods. [[1]](diffhunk://#diff-339d9a24d3b7eb2e758835bd7ace6c6b7214838ebb7a9445f22e49b77582e4d4R184-R188) [[2]](diffhunk://#diff-339d9a24d3b7eb2e758835bd7ace6c6b7214838ebb7a9445f22e49b77582e4d4L226-R236)
* Updated the `CategoryService` logic so that updating or patching a category propagates changes to the `available` and `printerId` fields to all related food items in a single transaction. [[1]](diffhunk://#diff-8ff03f931b4f7c6ee81501177839958a8b9e83d409d5d8fef299e3f75ef7ebc3L88-R107) [[2]](diffhunk://#diff-8ff03f931b4f7c6ee81501177839958a8b9e83d409d5d8fef299e3f75ef7ebc3L107-R125)

### Schema and Typing Consistency

* Fixed import in `category.route.ts` to use the correct `UpdateCategorySchema` instead of `UpdateFoodSchema`, and ensured the correct schema is used for request validation. [[1]](diffhunk://#diff-339d9a24d3b7eb2e758835bd7ace6c6b7214838ebb7a9445f22e49b77582e4d4L5-R5) [[2]](diffhunk://#diff-339d9a24d3b7eb2e758835bd7ace6c6b7214838ebb7a9445f22e49b77582e4d4L215-R220)
* Updated `PatchCategorySchema` and `PatchFoodSchema` to allow `printerId` to be `null` or omitted, supporting removal of printer associations. [[1]](diffhunk://#diff-46931901a6d4cd3622cbfef554635d6d8f49f4dd3867d783e1907da5e57b608cL24-R24) [[2]](diffhunk://#diff-48f718869ee813e242cc5953659bcd54175b3418c30ab35dd0acc89d70293431L42-R42)
* Ensured food update logic in `FoodService` supports updating `printerId` as well as `available`.

### Food API Documentation Update

* Improved the OpenAPI documentation for food updates to include the `printerId` field, clarifying its usage and example.