### PR TITLE
🛠️ Fixed Publish CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./docker/images/mysagra-myamministratore/Dockerfile
+          file: ./docker/images/mysagra-frontend/Dockerfile
           push: true
           tags: ghcr.io/mysagra/${{ env.IMAGE_NAME_FRONTEND }}:latest
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing Docker images. The main change is that the workflow now builds and pushes the frontend Docker image instead of the previous image.

**Workflow update:**

* The `publish.yml` workflow now uses the `mysagra-frontend` Dockerfile (`./docker/images/mysagra-frontend/Dockerfile`) instead of the `mysagra-myamministratore` Dockerfile for building and pushing the frontend image.