### PR TITLE
🐋 Fixed docker compose

### DIFF
--- a/docker/images/mysagra-backend/Dockerfile
+++ b/docker/images/mysagra-backend/Dockerfile
@@ -6,10 +6,10 @@ RUN apk update && apk add --no-cache libc6-compat curl
 # Set working directory
 WORKDIR /app
 RUN corepack enable
-RUN yarn global add turbo@^2
+RUN corepack prepare pnpm@9.0.0 --activate
 COPY . .
 # Generate a partial monorepo with a pruned lockfile for a target workspace.
-RUN turbo prune mysagra-backend --docker
+RUN pnpm dlx turbo@^2 prune mysagra-backend --docker
 
 FROM base AS installer
 # Install system dependencies for Prisma

--- a/docker/images/mysagra-frontend/Dockerfile
+++ b/docker/images/mysagra-frontend/Dockerfile
@@ -5,11 +5,12 @@ RUN apk update
 RUN apk add --no-cache libc6-compat
 # Set working directory
 WORKDIR /app
-RUN yarn global add turbo@^2
+RUN corepack enable
+RUN corepack prepare pnpm@9.0.0 --activate
 COPY . .
  
 # Generate a partial monorepo with a pruned lockfile for a target workspace.
-RUN turbo prune mysagra-frontend --docker
+RUN pnpm dlx turbo@^2 prune mysagra-frontend --docker
  
 # Add lockfile and package.json's of isolated subworkspace
 FROM base AS installer


### PR DESCRIPTION
This pull request updates the Docker build process for both the backend and frontend images to use `pnpm` instead of `yarn` for package management and monorepo pruning. The changes streamline dependency management and improve compatibility with the latest tooling.

Dependency management migration:

* Replaced `yarn` with `pnpm` by enabling `corepack` and preparing `pnpm@9.0.0` in both `docker/images/mysagra-backend/Dockerfile` and `docker/images/mysagra-frontend/Dockerfile`. [[1]](diffhunk://#diff-a54e7e54293bdd4505328b94fb4692def8ee1f5b23eb9a183b0fe63e751453a4L9-R12) [[2]](diffhunk://#diff-671e33998bb5bf0ff609beb79a253ceb71a65d19d23cdfde521dd6fe6e9da952L8-R13)

Monorepo pruning update:

* Changed the pruning command to use `pnpm dlx turbo@^2` instead of `yarn` or direct `turbo` invocation, ensuring lockfile compatibility and proper workspace isolation for both backend and frontend Docker images. [[1]](diffhunk://#diff-a54e7e54293bdd4505328b94fb4692def8ee1f5b23eb9a183b0fe63e751453a4L9-R12) [[2]](diffhunk://#diff-671e33998bb5bf0ff609beb79a253ceb71a65d19d23cdfde521dd6fe6e9da952L8-R13)