### PR TITLE
🛠️ Added null value for update, fixed dialogs

### DIFF
--- a/apps/frontend/components/dashboard/cash-registers/cash-register-dialog.tsx
+++ b/apps/frontend/components/dashboard/cash-registers/cash-register-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useForm, FormProvider } from "react-hook-form";
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
 import { z } from "zod";
@@ -16,16 +16,6 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import {
   Select,
   SelectContent,
@@ -74,7 +64,6 @@ export function CashRegisterDialog({
   const { t } = useLocale();
   const { canDelete } = useRole();
   const isEditing = !!cashRegister;
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const cashRegisterSchema = z.object({
     name: z.string().min(1, t.cashRegisters.nameRequired),
@@ -129,17 +118,8 @@ export function CashRegisterDialog({
     }
   }
 
-  function handleDeleteConfirm() {
-    if (cashRegister && onDelete) {
-      setShowDeleteConfirm(false);
-      onDelete(cashRegister);
-      onOpenChange(false);
-    }
-  }
-
   return (
-    <>
-      <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle className="text-xl">
@@ -227,7 +207,7 @@ export function CashRegisterDialog({
                   <Button
                     type="button"
                     variant="destructive"
-                    onClick={() => setShowDeleteConfirm(true)}
+                    onClick={() => { onDelete!(cashRegister!); onOpenChange(false); }}
                     className="mr-auto"
                   >
                     <Trash2Icon className="h-4 w-4 mr-2" />
@@ -253,28 +233,5 @@ export function CashRegisterDialog({
           </FormProvider>
         </DialogContent>
       </Dialog>
-
-      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t.cashRegisters.confirmDeletionTitle}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t.cashRegisters.confirmDeletionDescription} <span className="font-bold">{cashRegister?.name}</span>?
-              <br />
-              {t.cashRegisters.cannotUndo}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t.common.cancel}</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDeleteConfirm}
-              variant="destructive"
-            >
-              {t.common.delete}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
   );
 }

--- a/apps/frontend/components/dashboard/categories/category-dialog.tsx
+++ b/apps/frontend/components/dashboard/categories/category-dialog.tsx
@@ -17,16 +17,6 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -86,7 +76,6 @@ export function CategoryDialog({
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const categorySchema = z.object({
     name: z.string().min(1, t.categories.nameRequired),
@@ -193,17 +182,8 @@ export function CategoryDialog({
     }
   }
 
-  function handleDeleteConfirm() {
-    if (category && onDelete) {
-      setShowDeleteConfirm(false);
-      onDelete(category);
-      onOpenChange(false);
-    }
-  }
-
   return (
-    <>
-      <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle className="text-xl select-none">
@@ -343,7 +323,7 @@ export function CategoryDialog({
                   <Button
                     type="button"
                     variant="destructive"
-                    onClick={() => setShowDeleteConfirm(true)}
+                    onClick={() => { onDelete!(category!); onOpenChange(false); }}
                     className="mr-auto"
                   >
                     <Trash2Icon className="h-4 w-4 mr-2" />
@@ -369,28 +349,5 @@ export function CategoryDialog({
           </FormProvider>
         </DialogContent>
       </Dialog>
-
-      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t.categories.confirmDeletionTitle}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t.categories.confirmDeletionDescription} <span className="font-bold">{category?.name}</span>?
-              <br />
-              {t.categories.cannotUndo}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t.common.cancel}</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDeleteConfirm}
-              variant="destructive"
-            >
-              {t.common.delete}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
   );
 }

--- a/apps/frontend/components/dashboard/foods/food-dialog.tsx
+++ b/apps/frontend/components/dashboard/foods/food-dialog.tsx
@@ -13,16 +13,6 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
@@ -81,7 +71,6 @@ export function FoodDialog({
   const [selectedIngredients, setSelectedIngredients] = useState<string[]>([]);
   const [ingredientSearch, setIngredientSearch] = useState("");
   const [selectedPrinterId, setSelectedPrinterId] = useState<string | null>(null);
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const foodSchema = z.object({
     name: z.string().min(1, t.foods.nameRequired),
@@ -166,17 +155,8 @@ export function FoodDialog({
     }
   }
 
-  function handleDeleteConfirm() {
-    if (food && onDelete) {
-      setShowDeleteConfirm(false);
-      onDelete(food);
-      onOpenChange(false);
-    }
-  }
-
   return (
-    <>
-      <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle className="text-xl">
@@ -367,7 +347,7 @@ export function FoodDialog({
                   <Button
                     type="button"
                     variant="destructive"
-                    onClick={() => setShowDeleteConfirm(true)}
+                    onClick={() => { onDelete!(food!); onOpenChange(false); }}
                     className="mr-auto"
                   >
                     <Trash2Icon className="h-4 w-4 mr-2" />
@@ -393,28 +373,5 @@ export function FoodDialog({
           </FormProvider>
         </DialogContent>
       </Dialog>
-
-      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t.foods.confirmDeletionTitle}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t.foods.confirmDeletionDescription} <span className="font-bold">{food?.name}</span>?
-              <br />
-              {t.foods.cannotUndo}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t.common.cancel}</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDeleteConfirm}
-              variant="destructive"
-            >
-              {t.common.delete}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
   );
 }

--- a/apps/frontend/components/dashboard/ingredients/ingredient-dialog.tsx
+++ b/apps/frontend/components/dashboard/ingredients/ingredient-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useForm, FormProvider } from "react-hook-form";
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
 import { z } from "zod";
@@ -13,16 +13,6 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Trash2Icon } from "lucide-react";
@@ -59,7 +49,6 @@ export function IngredientDialog({
   const { t } = useLocale();
   const { canDelete } = useRole();
   const isEditing = !!ingredient;
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const ingredientSchema = z.object({
     name: z.string().min(1, t.ingredients.nameRequired),
@@ -102,17 +91,8 @@ export function IngredientDialog({
     }
   }
 
-  function handleDeleteConfirm() {
-    if (ingredient && onDelete) {
-      setShowDeleteConfirm(false);
-      onDelete(ingredient);
-      onOpenChange(false);
-    }
-  }
-
   return (
-    <>
-      <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle className="text-xl">
@@ -147,7 +127,7 @@ export function IngredientDialog({
                   <Button
                     type="button"
                     variant="destructive"
-                    onClick={() => setShowDeleteConfirm(true)}
+                    onClick={() => { onDelete!(ingredient!); onOpenChange(false); }}
                     className="mr-auto"
                   >
                     <Trash2Icon className="h-4 w-4 mr-2" />
@@ -173,28 +153,5 @@ export function IngredientDialog({
           </FormProvider>
         </DialogContent>
       </Dialog>
-
-      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t.ingredients.confirmDeletionTitle}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t.ingredients.confirmDeletionDescription} <span className="font-bold">{ingredient?.name}</span>?
-              <br />
-              {t.ingredients.cannotUndo}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t.common.cancel}</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDeleteConfirm}
-              variant="destructive"
-            >
-              {t.common.delete}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
   );
 }

--- a/apps/frontend/components/dashboard/printers/printer-dialog.tsx
+++ b/apps/frontend/components/dashboard/printers/printer-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useForm, FormProvider, type Resolver } from "react-hook-form";
 import { standardSchemaResolver } from "@hookform/resolvers/standard-schema";
 import { z } from "zod";
@@ -13,16 +13,6 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { Input } from "@/components/ui/input";
 import { MacAddressInput } from "@/components/ui/mac-address-input";
 import { Button } from "@/components/ui/button";
@@ -57,7 +47,6 @@ export function PrinterDialog({
   const { t } = useLocale();
   const { canDelete } = useRole();
   const isEditing = !!printer;
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const printerSchema = z.object({
     name: z.string().min(1, t.printers.nameRequired),
@@ -113,14 +102,15 @@ export function PrinterDialog({
 
   async function onSubmit(values: PrinterFormValues) {
     try {
-      const ip = (values.ip as string | undefined)?.trim();
-      const mac = (values.mac as string | undefined)?.trim();
+      const ip = (values.ip as string | undefined)?.trim() || null;
+      const mac = (values.mac as string | undefined)?.trim() || null;
+      const description = (values.description as string | undefined)?.trim() || undefined;
       const data = {
         name: values.name.trim(),
-        ...(ip ? { ip } : {}),
-        ...(mac ? { mac } : {}),
+        ip,
+        mac,
         port: values.port as number,
-        description: (values.description as string | undefined)?.trim() ?? "",
+        description,
       };
 
       if (isEditing && printer) {
@@ -140,17 +130,8 @@ export function PrinterDialog({
     }
   }
 
-  function handleDeleteConfirm() {
-    if (printer && onDelete) {
-      setShowDeleteConfirm(false);
-      onDelete(printer);
-      onOpenChange(false);
-    }
-  }
-
   return (
-    <>
-      <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>
@@ -255,7 +236,7 @@ export function PrinterDialog({
                   <Button
                     type="button"
                     variant="destructive"
-                    onClick={() => setShowDeleteConfirm(true)}
+                    onClick={() => { onDelete!(printer!); onOpenChange(false); }}
                     className="mr-auto"
                   >
                     <Trash2Icon className="h-4 w-4 mr-2" />
@@ -281,28 +262,5 @@ export function PrinterDialog({
           </FormProvider>
         </DialogContent>
       </Dialog>
-
-      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t.printers.confirmDeletionTitle}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t.printers.confirmDeletionDescription} <span className="font-bold">{printer?.name}</span>?
-              <br />
-              {t.printers.cannotUndo}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>{t.common.cancel}</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDeleteConfirm}
-              variant="destructive"
-            >
-              {t.common.delete}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
   );
 }

--- a/apps/frontend/lib/api-types.ts
+++ b/apps/frontend/lib/api-types.ts
@@ -173,8 +173,8 @@ export interface Printer {
 
 export interface PrinterRequest {
   name: string;
-  ip?: string;
-  mac?: string;
+  ip?: string | null;
+  mac?: string | null;
   port: number;
   description?: string;
   status?: "ONLINE" | "OFFLINE" | "ERROR";

--- a/packages/schemas/src/printer.schema.ts
+++ b/packages/schemas/src/printer.schema.ts
@@ -15,11 +15,11 @@ const PrinterBase = {
     ip: z.ipv4().meta({
         description: "IPv4 address of the printer",
         example: "192.168.1.100"
-    }).optional(),
+    }).optional().nullable(),
     mac: z.mac().meta({
         description: "MAC address of the printer",
         example: "AA:BB:00:F2:11:66"
-    }).optional(),
+    }).optional().nullable(),
     port: z.number().int().min(0).max(65535).default(9100).meta({
         description: "Port number for printer communication",
         example: 9100


### PR DESCRIPTION
This pull request simplifies the deletion confirmation flow for dialogs in the dashboard components by removing the `AlertDialog` confirmation step. Now, when a user clicks the delete button, the item is deleted immediately without an extra confirmation dialog. The code is also cleaned up by removing related state and handlers, and unnecessary imports. Additionally, there is a small improvement in the printer dialog to ensure empty fields are handled consistently.

**Dialog Deletion Flow Simplification:**

* Removed the `AlertDialog` confirmation step from the dialogs for cash registers, categories, foods, ingredients, and printers. Now, clicking the delete button immediately triggers the deletion and closes the dialog. [[1]](diffhunk://#diff-fa7e688d7b6c206c3cfc24a43a66d9e8988e62393c5937f725b30940a7eb2ae2L19-L28) [[2]](diffhunk://#diff-fa7e688d7b6c206c3cfc24a43a66d9e8988e62393c5937f725b30940a7eb2ae2L77) [[3]](diffhunk://#diff-fa7e688d7b6c206c3cfc24a43a66d9e8988e62393c5937f725b30940a7eb2ae2L132-L141) [[4]](diffhunk://#diff-fa7e688d7b6c206c3cfc24a43a66d9e8988e62393c5937f725b30940a7eb2ae2L230-R210) [[5]](diffhunk://#diff-fa7e688d7b6c206c3cfc24a43a66d9e8988e62393c5937f725b30940a7eb2ae2L256-L278) [[6]](diffhunk://#diff-33d1c1e1e265762077c5813cb411fb1174bcdf637c89021fc45628771897ec27L20-L29) [[7]](diffhunk://#diff-33d1c1e1e265762077c5813cb411fb1174bcdf637c89021fc45628771897ec27L89) [[8]](diffhunk://#diff-33d1c1e1e265762077c5813cb411fb1174bcdf637c89021fc45628771897ec27L196-L205) [[9]](diffhunk://#diff-33d1c1e1e265762077c5813cb411fb1174bcdf637c89021fc45628771897ec27L346-R326) [[10]](diffhunk://#diff-33d1c1e1e265762077c5813cb411fb1174bcdf637c89021fc45628771897ec27L372-L394) [[11]](diffhunk://#diff-31b5a4095e6c0c9107bd9fd069d15a0ea57cdd4e60cbd77a79a0934bab2b42dfL16-L25) [[12]](diffhunk://#diff-31b5a4095e6c0c9107bd9fd069d15a0ea57cdd4e60cbd77a79a0934bab2b42dfL84) [[13]](diffhunk://#diff-31b5a4095e6c0c9107bd9fd069d15a0ea57cdd4e60cbd77a79a0934bab2b42dfL169-L178) [[14]](diffhunk://#diff-31b5a4095e6c0c9107bd9fd069d15a0ea57cdd4e60cbd77a79a0934bab2b42dfL370-R350) [[15]](diffhunk://#diff-31b5a4095e6c0c9107bd9fd069d15a0ea57cdd4e60cbd77a79a0934bab2b42dfL396-L418) [[16]](diffhunk://#diff-93749a20a9a1b70ccbb352febbb874efe83c167369e05868cac00a42880eeecaL3-R3) [[17]](diffhunk://#diff-93749a20a9a1b70ccbb352febbb874efe83c167369e05868cac00a42880eeecaL16-L25) [[18]](diffhunk://#diff-93749a20a9a1b70ccbb352febbb874efe83c167369e05868cac00a42880eeecaL62) [[19]](diffhunk://#diff-93749a20a9a1b70ccbb352febbb874efe83c167369e05868cac00a42880eeecaL105-L114) [[20]](diffhunk://#diff-93749a20a9a1b70ccbb352febbb874efe83c167369e05868cac00a42880eeecaL150-R130) [[21]](diffhunk://#diff-93749a20a9a1b70ccbb352febbb874efe83c167369e05868cac00a42880eeecaL176-L198) [[22]](diffhunk://#diff-bca41c016fc3418dc85ec33abe48c18400711d1dcf1c0fc859c2baa0495c6393L3-R3) [[23]](diffhunk://#diff-bca41c016fc3418dc85ec33abe48c18400711d1dcf1c0fc859c2baa0495c6393L16-L25) [[24]](diffhunk://#diff-bca41c016fc3418dc85ec33abe48c18400711d1dcf1c0fc859c2baa0495c6393L60) [[25]](diffhunk://#diff-bca41c016fc3418dc85ec33abe48c18400711d1dcf1c0fc859c2baa0495c6393L143-L152) [[26]](diffhunk://#diff-bca41c016fc3418dc85ec33abe48c18400711d1dcf1c0fc859c2baa0495c6393L258-R239)

**Code Cleanup:**

* Removed unused state variables (`showDeleteConfirm`) and related handler functions from all affected dialog components, resulting in cleaner and more maintainable code. [[1]](diffhunk://#diff-fa7e688d7b6c206c3cfc24a43a66d9e8988e62393c5937f725b30940a7eb2ae2L77) [[2]](diffhunk://#diff-fa7e688d7b6c206c3cfc24a43a66d9e8988e62393c5937f725b30940a7eb2ae2L132-L141) [[3]](diffhunk://#diff-33d1c1e1e265762077c5813cb411fb1174bcdf637c89021fc45628771897ec27L89) [[4]](diffhunk://#diff-33d1c1e1e265762077c5813cb411fb1174bcdf637c89021fc45628771897ec27L196-L205) [[5]](diffhunk://#diff-31b5a4095e6c0c9107bd9fd069d15a0ea57cdd4e60cbd77a79a0934bab2b42dfL84) [[6]](diffhunk://#diff-31b5a4095e6c0c9107bd9fd069d15a0ea57cdd4e60cbd77a79a0934bab2b42dfL169-L178) [[7]](diffhunk://#diff-93749a20a9a1b70ccbb352febbb874efe83c167369e05868cac00a42880eeecaL62) [[8]](diffhunk://#diff-93749a20a9a1b70ccbb352febbb874efe83c167369e05868cac00a42880eeecaL105-L114) [[9]](diffhunk://#diff-bca41c016fc3418dc85ec33abe48c18400711d1dcf1c0fc859c2baa0495c6393L60) [[10]](diffhunk://#diff-bca41c016fc3418dc85ec33abe48c18400711d1dcf1c0fc859c2baa0495c6393L143-L152)

**Printer Dialog Improvements:**

* Improved handling of empty `ip`, `mac`, and `description` fields in the printer dialog to ensure they are set to `null` or `undefined` instead of empty strings, which can help with backend data consistency.

These changes make the dialogs more streamlined and the code easier to maintain, but remove the extra safety net of a deletion confirmation step.