### PR TITLE
Feat/available events

### DIFF
--- a/apps/backend/src/modules/categories/categories.route.ts
+++ b/apps/backend/src/modules/categories/categories.route.ts
@@ -47,7 +47,7 @@ router.post(
 
 router.put(
     "/:id",
-    authenticate(["admin"]),
+    authenticate(["admin", "maintainer"]),
     validateRequest({
         params: cuidParamSchema,
         body: UpdateCategorySchema
@@ -57,7 +57,7 @@ router.put(
 
 router.patch(
     "/:id",
-    authenticate(["admin"]),
+    authenticate(["admin", "maintainer"]),
     validateRequest({
         params: cuidParamSchema,
         body: PatchCategorySchema
@@ -67,7 +67,7 @@ router.patch(
 
 router.patch(
     "/:id/image",
-    authenticate(["admin"]),
+    authenticate(["admin", "maintainer"]),
     validateRequest({
         params: cuidParamSchema
     }),

--- a/apps/backend/src/modules/categories/categories.service.ts
+++ b/apps/backend/src/modules/categories/categories.service.ts
@@ -8,9 +8,11 @@ import {
 import { prisma, Prisma } from "@mysagra/database";
 import { FoodsService } from "../foods/foods.service";
 import { ImagesService } from "../images/images.service";
+import { EventsService } from "../events/events.service";
 
 export class CategoriesService {
     public static imageService = new ImagesService('categories', 'category');
+    private event = EventsService.getIstance('cashier')
 
     async getCategories(queryParams?: GetCategoriesQuery) {
         const whereClause: Prisma.CategoryWhereInput = {}
@@ -90,7 +92,7 @@ export class CategoriesService {
     }
 
     async updateCategory(id: string, category: UpdateCategoryInput) {
-        return await prisma.$transaction(async (tx) => {
+        const updatedCategory = await prisma.$transaction(async (tx) => {
             const updateCategory = await tx.category.update({
                 where: {
                     id
@@ -110,10 +112,20 @@ export class CategoriesService {
             await tx.food.updateMany(foodUpdate)
             return updateCategory;
         })
+
+        this.event.broadcastEvent(
+            {
+                id: updatedCategory.id,
+                available: updatedCategory.available
+            },
+            "category-availability-changed"
+        )
+
+        return updatedCategory;
     }
 
     async patchCategory(id: string, category: PatchCategoryInput) {
-        return await prisma.$transaction(async (tx) => {
+        const patchedCategory = await prisma.$transaction(async (tx) => {
             const patchCategory = await tx.category.update({
                 where: {
                     id
@@ -134,6 +146,18 @@ export class CategoriesService {
             await tx.food.updateMany(foodUpdate)
             return patchCategory;
         })
+
+        if (category.available) {
+            this.event.broadcastEvent(
+                {
+                    id: patchedCategory.id,
+                    available: patchedCategory.available
+                },
+                "category-availability-changed"
+            )
+        }
+
+        return patchedCategory;
     }
 
     async deleteCategory(id: string) {
@@ -148,7 +172,7 @@ export class CategoriesService {
                 CategoriesService.imageService.delete(category.image)
             }
             return null;
-        }catch(error){
+        } catch (error) {
             return null;
         }
     }

--- a/apps/backend/src/modules/categories/categories.service.ts
+++ b/apps/backend/src/modules/categories/categories.service.ts
@@ -147,7 +147,7 @@ export class CategoriesService {
             return patchCategory;
         })
 
-        if (category.available) {
+        if (category.available !== undefined) {
             this.event.broadcastEvent(
                 {
                     id: patchedCategory.id,

--- a/apps/backend/src/modules/events/events.docs.ts
+++ b/apps/backend/src/modules/events/events.docs.ts
@@ -58,9 +58,27 @@ const SSEReprintOrderSchema = SSEOrderSchema.extend({
         .meta({ description: "Items selected for reprint" }),
 });
 
+const SSEFoodAvailabilitySchema = z.object({
+    id: z.string().meta({ example: "cjld2cyuq0000t3rmniod1foy" }),
+    available: z.boolean().meta({ example: true }),
+}).meta({ id: "SSEFoodAvailability" });
+
+const SSECategoryAvailabilitySchema = z.object({
+    id: z.string().meta({ example: "cjld2cyuq0000t3rmniod1foy" }),
+    available: z.boolean().meta({ example: false }),
+}).meta({ id: "SSECategoryAvailability" });
+
+const SSEPrinterStatusSchema = z.object({
+    id: z.string().meta({ example: "cjld2cyuq0000t3rmniod1foy" }),
+    status: z.enum(["ONLINE", "OFFLINE", "ERROR"]).meta({ example: "OFFLINE" }),
+}).meta({ id: "SSEPrinterStatus" });
+
 registry.register("SSEOrder", SSEOrderSchema);
 registry.register("SSEConfirmedOrderSummary", SSEConfirmedOrderSummary);
 registry.register("SSEReprintOrder", SSEReprintOrderSchema);
+registry.register("SSEFoodAvailability", SSEFoodAvailabilitySchema);
+registry.register("SSECategoryAvailability", SSECategoryAvailabilitySchema);
+registry.register("SSEPrinterStatus", SSEPrinterStatusSchema);
 
 // ─── Routes ──────────────────────────────────────────────────────────────────
 
@@ -78,6 +96,9 @@ registry.registerPath({
 ### \`cashier\` channel
 - **\`new-order\`** — Fired when a new order is placed. Payload: full order object (\`SSEOrder\`).
 - **\`confirmed-order\`** — Fired when an order is confirmed. Payload: \`SSEConfirmedOrderSummary\`.
+- **\`food-availability-changed\`** — Fired when a food item's availability changes. Payload: \`SSEFoodAvailability\`.
+- **\`category-availability-changed\`** — Fired when a category's availability changes. Payload: \`SSECategoryAvailability\`.
+- **\`printer-status-changed\`** — Fired when a printer's status changes. Payload: \`SSEPrinterStatus\`.
 
 ### \`display\` channel
 - **\`confirmed-order\`** — Fired when an order is confirmed. Payload: \`SSEConfirmedOrderSummary\`.

--- a/apps/backend/src/modules/foods/foods.service.ts
+++ b/apps/backend/src/modules/foods/foods.service.ts
@@ -1,10 +1,10 @@
 import { prisma, Prisma } from "@mysagra/database";
-import { 
-    GetFoodsQueryParams, 
-    GetFoodQueryParams, 
-    CreateFoodInput, 
-    PatchFoodInput, 
-    UpdateFoodInput 
+import {
+    GetFoodsQueryParams,
+    GetFoodQueryParams,
+    CreateFoodInput,
+    PatchFoodInput,
+    UpdateFoodInput
 } from "@mysagra/schemas";
 import { EventsService } from "../events/events.service";
 
@@ -169,6 +169,15 @@ export class FoodsService {
         if (food.ingredients && food.ingredients.length > 0) {
             return FoodsService.formatFoodResponse(updatedFood);
         }
+
+        // broadcast new available status
+        this.event.broadcastEvent(
+            {
+                id: updatedFood.id,
+                available: updatedFood.available
+            },
+            "food-availability-changed"
+        )
 
         return updatedFood;
     }

--- a/apps/backend/src/modules/foods/foods.service.ts
+++ b/apps/backend/src/modules/foods/foods.service.ts
@@ -193,7 +193,7 @@ export class FoodsService {
             }
         })
 
-        if (food.available) {
+        if (food.available !== undefined) {
             this.event.broadcastEvent(
                 {
                     id: patchedFood.id,

--- a/apps/backend/src/modules/printers/printers.service.ts
+++ b/apps/backend/src/modules/printers/printers.service.ts
@@ -24,15 +24,25 @@ export class PrintersService {
     }
 
     async updatePrinter(id: string, printer: UpdatePrinterInput) {
-        return await prisma.printer.update({
+        const updatedPrinter = await prisma.printer.update({
             where: {
                 id
             },
             data: printer
         })
+
+        this.cashierEvent.broadcastEvent(
+            {
+                id,
+                status: updatedPrinter.status
+            },
+            "printer-status-changed"
+        )
+
+        return updatedPrinter;
     }
 
-    async patchPrinter(id: string, printer: PatchPrinterInput){
+    async patchPrinter(id: string, printer: PatchPrinterInput) {
         const patchedPrinter = await prisma.printer.update({
             where: {
                 id
@@ -45,11 +55,11 @@ export class PrintersService {
         this.cashierEvent.broadcastEvent(
             {
                 id,
-                status: printer.status
+                status: patchedPrinter.status
             },
             "printer-status-changed"
         )
-        
+
         return patchedPrinter;
     }
 

--- a/apps/frontend/components/app-sidebar.tsx
+++ b/apps/frontend/components/app-sidebar.tsx
@@ -42,6 +42,7 @@ export function AppSidebar({ user, userRole, ...props }: AppSidebarProps) {
   const { t } = useLocale()
 
   const isAdmin = userRole === "admin"
+  const isMaintainer = userRole === "maintainer"
 
   const navItems = {
     home: [
@@ -52,7 +53,7 @@ export function AppSidebar({ user, userRole, ...props }: AppSidebarProps) {
       },
     ],
     cucina: [
-      ...(isAdmin
+      ...(isAdmin || isMaintainer
         ? [{ title: t.nav.categories, url: "/dashboard/categories", icon: LayoutGridIcon }]
         : []),
       {

--- a/apps/frontend/components/dashboard/categories/categories-content.tsx
+++ b/apps/frontend/components/dashboard/categories/categories-content.tsx
@@ -8,6 +8,7 @@ import { CategoriesTable } from "./categories-table";
 import { CategoryDialog } from "./category-dialog";
 import { DeleteCategoryDialog } from "./delete-category-dialog";
 import { toast } from "sonner";
+import { useRole } from "@/hooks/use-role";
 
 interface CategoriesContentProps {
   initialCategories: Category[];
@@ -15,6 +16,7 @@ interface CategoriesContentProps {
 }
 
 export function CategoriesContent({ initialCategories, printers }: CategoriesContentProps) {
+  const { canManageCategories } = useRole();
   const [categories, setCategories] = useState<Category[]>(
     [...initialCategories].sort((a, b) => a.position - b.position)
   );
@@ -114,6 +116,7 @@ export function CategoriesContent({ initialCategories, printers }: CategoriesCon
           onResetOrder={handleResetOrder}
           hasOrderChanged={hasOrderChanged}
           isSavingOrder={isSavingOrder}
+          canCreate={canManageCategories}
         />
         <CategoriesTable
           categories={filteredCategories}
@@ -128,7 +131,7 @@ export function CategoriesContent({ initialCategories, printers }: CategoriesCon
           category={editingCategory}
           printers={printers}
           onSaved={handleSaved}
-          onDelete={handleDelete}
+          onDelete={canManageCategories ? handleDelete : undefined}
           categoriesCount={categories.length}
         />
         <DeleteCategoryDialog

--- a/apps/frontend/components/dashboard/categories/categories-toolbar.tsx
+++ b/apps/frontend/components/dashboard/categories/categories-toolbar.tsx
@@ -13,6 +13,7 @@ interface CategoriesToolbarProps {
   onResetOrder: () => void;
   hasOrderChanged: boolean;
   isSavingOrder: boolean;
+  canCreate?: boolean;
 }
 
 export function CategoriesToolbar({
@@ -23,6 +24,7 @@ export function CategoriesToolbar({
   onResetOrder,
   hasOrderChanged,
   isSavingOrder,
+  canCreate = true,
 }: CategoriesToolbarProps) {
   const { t } = useLocale();
 
@@ -62,10 +64,12 @@ export function CategoriesToolbar({
             </Button>
           </>
         )}
-        <Button onClick={onCreateNew}>
-          <PlusIcon className="h-4 w-4 mr-2" />
-          {t.categories.newCategory}
-        </Button>
+        {canCreate && (
+          <Button onClick={onCreateNew}>
+            <PlusIcon className="h-4 w-4 mr-2" />
+            {t.categories.newCategory}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/apps/frontend/hooks/use-role.ts
+++ b/apps/frontend/hooks/use-role.ts
@@ -16,6 +16,8 @@ export function useRole() {
     canDelete: role === "admin",
     // Full CRUD on master data — admin only
     canManageUsers: role === "admin",
+    canViewCategories: role === "admin" || role === "maintainer",
+    canEditCategories: role === "admin" || role === "maintainer",
     canManageCategories: role === "admin",
     // Create/delete printers — admin only
     canCreatePrinters: role === "admin",

--- a/apps/frontend/proxy.ts
+++ b/apps/frontend/proxy.ts
@@ -18,10 +18,10 @@ export default auth((req) => {
     return NextResponse.redirect(new URL("/dashboard", req.nextUrl.origin));
   }
 
-  // Maintainer non può accedere a utenti e categorie
+  // Maintainer non può accedere agli utenti
   const role = (req.auth as any)?.user?.role as string | undefined;
   if (isLoggedIn && role === "maintainer") {
-    const restricted = ["/dashboard/users", "/dashboard/categories"];
+    const restricted = ["/dashboard/users"];
     if (restricted.some((p) => pathname.startsWith(p))) {
       return NextResponse.redirect(new URL("/dashboard", req.nextUrl.origin));
     }

--- a/packages/schemas/src/event.schema.ts
+++ b/packages/schemas/src/event.schema.ts
@@ -10,6 +10,7 @@ const eventName = z.enum([
     "new-order",
     "confirmed-order",
     "food-availability-changed",
+    "category-availability-changed",
     "printer-status-changed",
     "reprint-order",
     "order-status-update"


### PR DESCRIPTION
This pull request introduces real-time event broadcasting for category, food, and printer availability/status changes, and refines role-based access control for maintainers in both the backend and frontend. The most important changes are grouped below.

**Event Broadcasting Enhancements:**

* The backend now broadcasts `"category-availability-changed"`, `"food-availability-changed"`, and `"printer-status-changed"` events via the `EventsService` whenever a category, food, or printer is updated or patched. This ensures that clients are notified in real time about availability or status changes. [[1]](diffhunk://#diff-5719e900900cf63f0d2c00723a2e9152321cd795496febd9014f8eb5049ae2f6R115-R128) [[2]](diffhunk://#diff-5719e900900cf63f0d2c00723a2e9152321cd795496febd9014f8eb5049ae2f6R149-R160) [[3]](diffhunk://#diff-1a256997be82e3ddb0f731a7e4de899a9550f5508f67f516efc4a7af1a75bef9R173-R181) [[4]](diffhunk://#diff-1a256997be82e3ddb0f731a7e4de899a9550f5508f67f516efc4a7af1a75bef9L187-R196) [[5]](diffhunk://#diff-421c114f5388390d0924bc5a657a044f52290003d131450763f37536f98726d5L27-R42) [[6]](diffhunk://#diff-421c114f5388390d0924bc5a657a044f52290003d131450763f37536f98726d5L48-R58)
* New event schemas (`SSECategoryAvailability`, `SSEFoodAvailability`, `SSEPrinterStatus`) are documented and registered for these events, and the OpenAPI documentation is updated accordingly. [[1]](diffhunk://#diff-3e4298f342c0d22a808297bcf051f9b2515b2577af7a59caabc909e3b13a0e5fR61-R81) [[2]](diffhunk://#diff-3e4298f342c0d22a808297bcf051f9b2515b2577af7a59caabc909e3b13a0e5fR99-R101) [[3]](diffhunk://#diff-daf96a5bad2efed7c6c4798b78eb4270ee2a792bddc6064af37b30803fcffdb2R13)

**Role-Based Access Control Updates:**

* Backend routes for updating and patching categories now allow both `"admin"` and `"maintainer"` roles, expanding access for maintainers. [[1]](diffhunk://#diff-c77d3ab5558e78ed3db0044a1d5427b9c3615ecd7c4ef860859779933024507bL50-R50) [[2]](diffhunk://#diff-c77d3ab5558e78ed3db0044a1d5427b9c3615ecd7c4ef860859779933024507bL60-R60) [[3]](diffhunk://#diff-c77d3ab5558e78ed3db0044a1d5427b9c3615ecd7c4ef860859779933024507bL70-R70)
* Frontend navigation and UI logic are updated so maintainers can access and manage categories. Category management actions (like deletion) are conditionally enabled based on the user’s role. [[1]](diffhunk://#diff-baa0ef0259bd64819183d72c54b37b8bb604c173f76563bfd56a7d814c5e22daR45) [[2]](diffhunk://#diff-baa0ef0259bd64819183d72c54b37b8bb604c173f76563bfd56a7d814c5e22daL55-R56) [[3]](diffhunk://#diff-7ff17bb8def302c8f76e44f20100b691ac32bcb05f403be9e87ef16ff37ec2aaR11-R19) [[4]](diffhunk://#diff-7ff17bb8def302c8f76e44f20100b691ac32bcb05f403be9e87ef16ff37ec2aaR119) [[5]](diffhunk://#diff-7ff17bb8def302c8f76e44f20100b691ac32bcb05f403be9e87ef16ff37ec2aaL131-R134) [[6]](diffhunk://#diff-923c02bbfe623dcac28bfe563fefe5f9cd5131dc0346d0c7561349d93528b3acR16) [[7]](diffhunk://#diff-923c02bbfe623dcac28bfe563fefe5f9cd5131dc0346d0c7561349d93528b3acR27) [[8]](diffhunk://#diff-923c02bbfe623dcac28bfe563fefe5f9cd5131dc0346d0c7561349d93528b3acR67-R72) [[9]](diffhunk://#diff-bb06cf35db42bcffa7a1234a9cad663b31fda7d31e1d66d0efdfb5f0714cb963R19-R20)
* The frontend proxy restriction for maintainers is loosened, allowing them to access categories but not users.

These changes collectively improve system responsiveness to state changes and clarify/expand the permissions for the maintainer role.