### PR TITLE
🛠️ Fixed default banner in docker container

### DIFF
--- a/docker/images/mysagra-backend/Dockerfile
+++ b/docker/images/mysagra-backend/Dockerfile
@@ -51,9 +51,13 @@ RUN addgroup --system --gid 1001 nodejs \
 COPY --from=installer --chown=express:nodejs /app/apps/backend/src           ./apps/backend/src
 COPY --from=installer --chown=express:nodejs /app/apps/backend/tsconfig.json ./apps/backend/tsconfig.json
 COPY --from=installer --chown=express:nodejs /app/apps/backend/package.json  ./apps/backend/package.json
-RUN mkdir -p ./apps/backend/public /app/logs /app/public \
-  && chown -R express:nodejs ./apps/backend/public /app/logs /app/public \
-  && chmod 755 ./apps/backend/public /app/logs /app/public
+RUN mkdir -p ./apps/backend/public /app/logs /app/public /app/public/uploads/banners /app/.defaults/banners \
+  && chown -R express:nodejs ./apps/backend/public /app/logs /app/public /app/.defaults \
+  && chmod 755 ./apps/backend/public /app/logs /app/public /app/.defaults
+
+# ── Default sponsor banner (staged for volume seeding via entrypoint) ──────────
+# Glob makes this a no-op when the file is absent (avoids build failure)
+COPY --from=builder --chown=express:nodejs /app/apps/backend/public/uploads/banners/banner-mysagra-default* /app/.defaults/banners/
 
 # ── @mysagra/database (source + generated Prisma client) ─────────────────
 COPY --from=installer --chown=express:nodejs /app/packages/database/src          ./packages/database/src

--- a/docker/images/mysagra-backend/entrypoint.sh
+++ b/docker/images/mysagra-backend/entrypoint.sh
@@ -3,7 +3,19 @@ set -e
 
 echo "Starting application..."
 
-mkdir -p /app/logs /app/public && chmod 755 /app/logs /app/public
+mkdir -p /app/logs /app/public/uploads/banners && chmod 755 /app/logs /app/public
+
+# Seed default banner into the volume (only if not already present)
+if [ -d /app/.defaults/banners ]; then
+  for f in /app/.defaults/banners/*; do
+    [ -f "$f" ] || continue
+    dest="/app/public/uploads/banners/$(basename "$f")"
+    if [ ! -f "$dest" ]; then
+      cp "$f" "$dest"
+      echo "Seeded default banner: $(basename "$f")"
+    fi
+  done
+fi
 
 if [ "$MIGRATE_ON_START" = "true" ]; then
   echo "Running Prisma migrations..."


### PR DESCRIPTION
This pull request updates the Docker setup and entrypoint script for the backend service to support seeding a default sponsor banner image into the application's public uploads directory. The changes ensure that a default banner is available on first startup without overwriting any existing banners.

**Dockerfile and entrypoint improvements:**

* Added creation of `/app/public/uploads/banners` and `/app/.defaults/banners` directories, and ensured correct permissions and ownership for these new paths (`docker/images/mysagra-backend/Dockerfile`).
* Added logic to copy a default banner image (`banner-mysagra-default*`) from the build context into `/app/.defaults/banners` during the Docker build (`docker/images/mysagra-backend/Dockerfile`).
* Updated the entrypoint script to seed any default banners from `/app/.defaults/banners` into `/app/public/uploads/banners` only if they do not already exist, preventing overwrites (`docker/images/mysagra-backend/entrypoint.sh`).

**File system and permissions:**

* Ensured all new directories have the correct permissions and are owned by the `express:nodejs` user/group for security and compatibility (`docker/images/mysagra-backend/Dockerfile`).

These changes make it easier to provide a default banner image and ensure it is present on startup, while preserving any user-uploaded banners.