### PR TITLE
💲For the general closure added in the body post the cash register

### DIFF
--- a/apps/backend/src/modules/events/events.docs.ts
+++ b/apps/backend/src/modules/events/events.docs.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { registry } from "@/config/swagger";
-import { eventSchema } from "@mysagra/schemas";
+import { eventSchema, ReportSchema } from "@mysagra/schemas";
 
 // ─── Schemas ────────────────────────────────────────────────────────────────
 
@@ -73,41 +73,13 @@ const SSEPrinterStatusSchema = z.object({
     status: z.enum(["ONLINE", "OFFLINE", "ERROR"]).meta({ example: "OFFLINE" }),
 }).meta({ id: "SSEPrinterStatus" });
 
-const SSEGeneralClosureReportSchema = z.object({
-    id: z.string().meta({ example: "cjld2cyuq0000t3rmniod1foy" }),
-    timestamp: z.coerce.date().meta({ example: "2026-01-15T19:00:00.000Z" }),
-    intervalInMinutes: z.number().meta({ example: 720, description: "Total minutes covered by closure report" }),
-    totalRevenue: z.number().meta({ example: 1234.50 }),
-    totalCashRevenue: z.number().meta({ example: 567.25 }),
-    totalCardRevenue: z.number().meta({ example: 667.25 }),
-    totalOrders: z.number().int().meta({ example: 45 }),
-    averageCompletitionTime: z.number().nullable().optional().meta({ example: 300000, description: "Average completion time in milliseconds" }),
-    categoryStats: z.array(z.object({
-        id: z.string(),
-        reportId: z.string(),
-        categoryId: z.string(),
-        categoryName: z.string(),
-        revenue: z.number(),
-        quantity: z.number(),
-        foodStats: z.array(z.object({
-            id: z.string(),
-            categoryStatsId: z.string(),
-            foodId: z.string(),
-            foodName: z.string(),
-            revenue: z.number(),
-            quantity: z.number()
-        }))
-    })),
-    cashRegisterStats: z.array(z.object({
-        id: z.string(),
-        reportId: z.string(),
-        cashRegisterId: z.string(),
-        cashRegisterName: z.string(),
-        totalRevenue: z.number(),
-        totalCardRevenue: z.number(),
-        totalCashRevenue: z.number()
-    }))
-}).meta({ id: "SSEGeneralClosureReport" });
+const SSEGeneralClosurePayloadSchema = z.object({
+    cashRegister: z.string().meta({
+        example: "cjld2cyuq0000t3rmniod1foy",
+        description: "Cash register CUID that triggered the closure report"
+    }),
+    report: z.array(ReportSchema).meta({ description: "Array of aggregated reports (typically one report for daily closure with groupBy='all')" })
+}).meta({ id: "SSEGeneralClosurePayload" });
 
 registry.register("SSEOrder", SSEOrderSchema);
 registry.register("SSEConfirmedOrderSummary", SSEConfirmedOrderSummary);
@@ -115,7 +87,7 @@ registry.register("SSEReprintOrder", SSEReprintOrderSchema);
 registry.register("SSEFoodAvailability", SSEFoodAvailabilitySchema);
 registry.register("SSECategoryAvailability", SSECategoryAvailabilitySchema);
 registry.register("SSEPrinterStatus", SSEPrinterStatusSchema);
-registry.register("SSEGeneralClosureReport", SSEGeneralClosureReportSchema);
+registry.register("SSEGeneralClosurePayload", SSEGeneralClosurePayloadSchema);
 
 // ─── Routes ──────────────────────────────────────────────────────────────────
 
@@ -143,7 +115,7 @@ registry.registerPath({
 ### \`printer\` channel
 - **\`confirmed-order\`** — Fired when an order is confirmed (includes food details for printing). Payload: full order object (\`SSEOrder\`).
 - **\`reprint-order\`** — Fired when a reprint is requested. Payload: \`SSEReprintOrder\`.
-- **\`general-closure\`** — Fired when daily closure report is generated. Contains aggregated statistics for the day. Payload: \`SSEGeneralClosureReport\`.`,
+- **\`general-closure\`** — Fired when daily closure report is generated. Contains aggregated statistics for the day. Payload: \`SSEGeneralClosurePayload\`.`,
     tags: ["Events (SSE)"],
     security: [{ cookieAuth: [] }, { apiKeyAuth: [] }],
     request: { params: EventParams },

--- a/apps/backend/src/modules/report/report.controller.ts
+++ b/apps/backend/src/modules/report/report.controller.ts
@@ -1,7 +1,7 @@
 import { Response } from "express";
 import { asyncHandler } from "@/utils/asyncHandler";
 import { TypedRequest } from "@/types/request";
-import { CUIDParam, GetReportsQuery } from "@mysagra/schemas";
+import { CUIDParam, GeneralClosureInput, GetReportsQuery } from "@mysagra/schemas";
 import { reportService } from "./report.service";
 import { NotFoundError } from "@/common/errors";
 
@@ -38,10 +38,10 @@ export class ReportController {
     });
 
     generalClosure = asyncHandler(async (
-        req: TypedRequest<{}>,
+        req: TypedRequest<{ body: GeneralClosureInput}>,
         res: Response,
     ): Promise<void> => {
-        const report = await ReportController.service.generalClosure();
+        const report = await ReportController.service.generalClosure(req.validated.body);
         res.status(201).json(report);
     })
 

--- a/apps/backend/src/modules/report/report.docs.ts
+++ b/apps/backend/src/modules/report/report.docs.ts
@@ -4,6 +4,7 @@ import {
     GetReportsQuerySchema,
     ReportSchema,
     cuidParamSchema,
+    GeneralClosureInputSchema,
 } from "@mysagra/schemas";
 
 // ─── Schemas ────────────────────────────────────────────────────────────────
@@ -11,6 +12,7 @@ import {
 const GetReportsQuery = registry.register("GetReportsQuery", GetReportsQuerySchema);
 const ReportResponse = registry.register("ReportResponse", ReportSchema);
 const CUIDParam = registry.register("CUIDParam", cuidParamSchema);
+const GeneralClosureInput = registry.register("GeneralClosureInput", GeneralClosureInputSchema);
 
 // ─── Routes ──────────────────────────────────────────────────────────────────
 
@@ -78,12 +80,22 @@ registry.registerPath({
         "Automatically broadcasts to printer channel for receipt printing. Requires admin or maintainer role.",
     tags: ["Reports"],
     security: [{ cookieAuth: [] }],
+    request: {
+        body: {
+            required: true,
+            content: {
+                "application/json": {
+                    schema: GeneralClosureInput,
+                },
+            },
+        },
+    },
     responses: {
         201: {
             description: "Closure report generated and broadcasted to printers",
             content: {
                 "application/json": {
-                    schema: ReportResponse,
+                    schema: z.array(ReportResponse),
                 },
             },
         },

--- a/apps/backend/src/modules/report/report.route.ts
+++ b/apps/backend/src/modules/report/report.route.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { authenticate } from "@/middlewares/authenticate";
 import { validateRequest } from "@/middlewares/validateRequest";
-import { cuidParamSchema, GetReportsQuerySchema } from "@mysagra/schemas";
+import { cuidParamSchema, GeneralClosureInputSchema, GetReportsQuerySchema } from "@mysagra/schemas";
 import { reportController } from "./report.controller";
 import "./report.docs";
 
@@ -28,6 +28,9 @@ router.get(
 
 router.post(
     "/general-closure",
+    validateRequest({
+        body: GeneralClosureInputSchema
+    }),
     authenticate(["admin", "maintainer"]),
     reportController.generalClosure
 )

--- a/apps/backend/src/modules/report/report.service.ts
+++ b/apps/backend/src/modules/report/report.service.ts
@@ -1,10 +1,11 @@
 import { Prisma, prisma } from "@mysagra/database"
 import { sagraService } from "../sagra/sagra.service"
-import { OrderStats, CategoryStats, FoodStats } from "@mysagra/schemas"
+import { OrderStats, CategoryStats, FoodStats, GeneralClosureInput } from "@mysagra/schemas"
 import { GetReportsQuery, GroupInterval } from "@mysagra/schemas"
 import { Report } from "@mysagra/schemas"
 import { logger } from "@/config/logger"
 import { EventsService } from "../events/events.service"
+import { BadRequestError } from "@/common/errors"
 
 export class ReportService {
     private static instance: ReportService
@@ -523,12 +524,16 @@ export class ReportService {
         })
     }
 
-    async generalClosure() {
+    async generalClosure(data: GeneralClosureInput) {
         const now = new Date();
         const from = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 7, 0, 0);
 
         if (now.getHours() < 7) {
             from.setDate(from.getDate() - 1);
+        }
+
+        if(!await prisma.cashRegister.findUnique({ where: { id: data.cashRegister }})){
+            throw new BadRequestError(`Cash register with CUID: ${data.cashRegister} doesn't exists`)
         }
 
         const report = await this.getReports({
@@ -537,7 +542,10 @@ export class ReportService {
         }, true)
 
         this.printerEvent.broadcastEvent(
-            report,
+            {
+                cashRegister: data.cashRegister,
+                report: report[0]
+            },
             "general-closure"
         )
 

--- a/packages/schemas/src/report.schema.ts
+++ b/packages/schemas/src/report.schema.ts
@@ -72,6 +72,14 @@ export const ReportSchema = z.object({
   cashRegisterStats: z.array(CashRegisterStatsSchema)
 })
 
+export const GeneralClosureInputSchema = z.object({
+  cashRegister: z.cuid().meta({
+    description: "Cash register CUID that request the general closure"
+  })
+})
+
+export type GeneralClosureInput = z.infer<typeof GeneralClosureInputSchema>
+
 export type Report = z.infer<typeof ReportSchema>
 
 export const GetStatsResponseSchema = z.array(ReportSchema)


### PR DESCRIPTION
This pull request introduces significant improvements to the general closure report feature, focusing on standardizing the API, improving schema validation, and ensuring more robust error handling. The main changes involve updating the payload structure for the general closure event, enforcing input validation, and enhancing the documentation to accurately reflect the new request and response formats.

**General Closure Report Improvements:**

* The general closure event payload has been refactored to use a new `SSEGeneralClosurePayload` schema, which includes both the triggering cash register ID and an array of aggregated reports, replacing the previous flat report structure. [[1]](diffhunk://#diff-3e4298f342c0d22a808297bcf051f9b2515b2577af7a59caabc909e3b13a0e5fL76-R90) [[2]](diffhunk://#diff-3e4298f342c0d22a808297bcf051f9b2515b2577af7a59caabc909e3b13a0e5fL146-R118)
* The backend endpoint for generating a general closure report now requires a validated request body (`GeneralClosureInput`) specifying the cash register, and returns an array of reports. [[1]](diffhunk://#diff-71a7b3bdd3153713665628ca074c426d4649ecfe6b066719860775c2dc04e313L4-R4) [[2]](diffhunk://#diff-71a7b3bdd3153713665628ca074c426d4649ecfe6b066719860775c2dc04e313L41-R44) [[3]](diffhunk://#diff-4740b5ef51264dc3f9c34c598d8681a197481b1bf63135b669aab7591826abafR7-R15) [[4]](diffhunk://#diff-4740b5ef51264dc3f9c34c598d8681a197481b1bf63135b669aab7591826abafR83-R98) [[5]](diffhunk://#diff-eb5c9478187ff4a1602e9c8191410c53a95959d1fdd7e593adb140f04deb4790L4-R4) [[6]](diffhunk://#diff-eb5c9478187ff4a1602e9c8191410c53a95959d1fdd7e593adb140f04deb4790R31-R33) [[7]](diffhunk://#diff-3643446d198ffd4c5b52fe9f3461fe42664a479624f87cefa7cfc34efaa06128R75-R82)

**Validation and Error Handling:**

* Input validation is enforced for the general closure endpoint using the new `GeneralClosureInputSchema`, ensuring only valid requests are processed. [[1]](diffhunk://#diff-eb5c9478187ff4a1602e9c8191410c53a95959d1fdd7e593adb140f04deb4790L4-R4) [[2]](diffhunk://#diff-eb5c9478187ff4a1602e9c8191410c53a95959d1fdd7e593adb140f04deb4790R31-R33) [[3]](diffhunk://#diff-3643446d198ffd4c5b52fe9f3461fe42664a479624f87cefa7cfc34efaa06128R75-R82)
* The service now checks for the existence of the specified cash register and throws a `BadRequestError` if it does not exist. [[1]](diffhunk://#diff-a08dfd21d5fca010996987d9f06eb3f41d1185b2a032c55083ef99cc08f97406L3-R8) [[2]](diffhunk://#diff-a08dfd21d5fca010996987d9f06eb3f41d1185b2a032c55083ef99cc08f97406L526-R548)

**Documentation Updates:**

* OpenAPI/Swagger documentation has been updated to reflect the new request and response schemas for the general closure endpoint and event, ensuring API consumers have accurate, up-to-date information. [[1]](diffhunk://#diff-3e4298f342c0d22a808297bcf051f9b2515b2577af7a59caabc909e3b13a0e5fL3-R3) [[2]](diffhunk://#diff-4740b5ef51264dc3f9c34c598d8681a197481b1bf63135b669aab7591826abafR7-R15) [[3]](diffhunk://#diff-4740b5ef51264dc3f9c34c598d8681a197481b1bf63135b669aab7591826abafR83-R98) [[4]](diffhunk://#diff-3e4298f342c0d22a808297bcf051f9b2515b2577af7a59caabc909e3b13a0e5fL146-R118)

These changes collectively make the general closure reporting process more robust, consistent, and easier to consume for both backend and frontend developers.…t request it, that will send in SSE for printers