### PR TITLE
Feat/stats

### DIFF
--- a/apps/backend/src/middlewares/validateApiKey.ts
+++ b/apps/backend/src/middlewares/validateApiKey.ts
@@ -55,7 +55,10 @@ export async function validateApiKey(req: Request, res: Response, next: NextFunc
             const activeData = { status: 'ACTIVE', prefix: dbKey.prefix, type: dbKey.type, lastUsedUpdatedAt: now.getTime() };
             await Promise.all([
                 redisConnection.setex(redisKey, env.REDIS_CACHE_TTL, JSON.stringify(activeData)),
-                prisma.apiKey.update({ where: { hash_key: hash }, data: { lastUsedAt: now } })
+                prisma.$transaction(async (tx) => {
+                    await tx.$queryRaw`SELECT * FROM api_key WHERE hash_key = ${hash} FOR UPDATE`;
+                    await tx.apiKey.update({ where: { hash_key: hash }, data: { lastUsedAt: now } });
+                })
             ]);
         }
         else {
@@ -70,7 +73,10 @@ export async function validateApiKey(req: Request, res: Response, next: NextFunc
                 const now = new Date();
                 const updatedData = { ...keyData, lastUsedUpdatedAt: now.getTime() };
                 redisConnection.setex(redisKey, env.REDIS_CACHE_TTL, JSON.stringify(updatedData))
-                    .then(() => prisma.apiKey.update({ where: { hash_key: hash }, data: { lastUsedAt: now } }))
+                    .then(() => prisma.$transaction(async (tx) => {
+                        await tx.$queryRaw`SELECT * FROM api_key WHERE hash_key = ${hash} FOR UPDATE`;
+                        await tx.apiKey.update({ where: { hash_key: hash }, data: { lastUsedAt: now } });
+                    }))
                     .catch(err => {
                         // Ignore P2025 (record not found) - can occur if key was deleted between Redis read and DB update
                         if (err.code !== 'P2025') {

--- a/apps/backend/src/modules/report/report.service.ts
+++ b/apps/backend/src/modules/report/report.service.ts
@@ -338,19 +338,20 @@ export class ReportService {
 
         // Get real-time stats for current interval
         const realtimeStats = await this._getRealTimeStats(query.from, query.to, saveLiveData);
+        const realtimeBucket = this._formatRealtimeReport(realtimeStats, new Date(), query.groupBy);
+
+        console.log(realtimeStats, realtimeBucket)
 
         if (query.groupBy === '1h') {
             // For 1h grouping, append real-time data
-            const realtimeBucket = this._formatRealtimeReport(realtimeStats, new Date(), '1h');
             return realtimeBucket ? [...rawReports, realtimeBucket] : rawReports;
         }
 
         const buckets = new Map<number, Report>();
         const bucketCompletitionTimeWeighted = new Map<number, number>();
 
-        // Add real-time data to reports for processing
-        const realtimeBucket = this._formatRealtimeReport(realtimeStats, new Date(), query.groupBy);
-        const reportsToProcess = realtimeBucket ? [...rawReports, realtimeBucket] : rawReports;
+        // Process only raw reports for aggregation (exclude real-time from aggregation)
+        const reportsToProcess = rawReports;
 
         for (const report of reportsToProcess) {
             const bucketKey = this.getBucketTimestamp(report.timestamp, query.groupBy);
@@ -495,7 +496,7 @@ export class ReportService {
             currentBucket.cashRegisterStats = Array.from(cashRegisterStatsMap.values());
         }
 
-        return Array.from(buckets.values())
+        const aggregatedReports = Array.from(buckets.values())
             .map(bucket => {
                 if (bucket.totalOrders > 0) {
                     const weightedTotal = bucketCompletitionTimeWeighted.get(bucket.timestamp.getTime());
@@ -506,6 +507,9 @@ export class ReportService {
                 return bucket;
             })
             .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+        // Append real-time data at the end
+        return realtimeBucket ? [...aggregatedReports, realtimeBucket] : aggregatedReports;
     }
 
     async getReport(id: string) {
@@ -536,10 +540,14 @@ export class ReportService {
             throw new BadRequestError(`Cash register with CUID: ${data.cashRegister} doesn't exists`)
         }
 
+        await this.generateReport(now);
+
         const report = await this.getReports({
             from,
             groupBy: 'all'
-        }, true)
+        }, false)
+
+        report[0].timestamp = now
 
         this.printerEvent.broadcastEvent(
             {


### PR DESCRIPTION
This pull request focuses on improving data consistency and accuracy in API key usage tracking and report generation. The main changes include making database updates for API key usage more robust by using transactions with row-level locking, and adjusting how real-time report data is aggregated and returned.

**API Key Usage Consistency:**
- Database updates for `lastUsedAt` in `validateApiKey` middleware are now wrapped in a transaction with a `SELECT ... FOR UPDATE` to ensure row-level locking and prevent race conditions during concurrent updates. [[1]](diffhunk://#diff-72dbe07ce08529e1e5763aa977bca41a26a785c87422260eaf1350b20055a4adL58-R61) [[2]](diffhunk://#diff-72dbe07ce08529e1e5763aa977bca41a26a785c87422260eaf1350b20055a4adL73-R79)

**Report Generation and Real-Time Data Handling:**
- Real-time report data (`realtimeBucket`) is now appended only after aggregation, ensuring that only raw reports are aggregated and real-time data is not double-counted. [[1]](diffhunk://#diff-a08dfd21d5fca010996987d9f06eb3f41d1185b2a032c55083ef99cc08f97406R341-R354) [[2]](diffhunk://#diff-a08dfd21d5fca010996987d9f06eb3f41d1185b2a032c55083ef99cc08f97406L498-R499) [[3]](diffhunk://#diff-a08dfd21d5fca010996987d9f06eb3f41d1185b2a032c55083ef99cc08f97406R510-R512)
- When generating a report for a specific cash register, a new report is generated before fetching reports, and the timestamp of the returned report is explicitly set to the current time.