### PR TITLE
Token now expires after 12h

### DIFF
--- a/apps/backend/src/modules/auth/auth.controller.ts
+++ b/apps/backend/src/modules/auth/auth.controller.ts
@@ -21,7 +21,7 @@ export class AuthController {
             secure: env.NODE_ENV === 'production',
             sameSite: 'lax',
             path: '/',
-            maxAge: 6 * 60 * 60 * 1000
+            maxAge: 12 * 60 * 60 * 1000
         });
 
         res.status(200).json({

--- a/apps/backend/src/modules/auth/token.service.ts
+++ b/apps/backend/src/modules/auth/token.service.ts
@@ -16,7 +16,7 @@ export class TokenService {
                 role: user.role.name
             },
             this.secret,
-            { expiresIn: "6h" }
+            { expiresIn: "12h" }
         );
     }
 
@@ -38,6 +38,7 @@ export class TokenService {
     getTokenPayload(token: string) {
         try {
             const payload = jwt.verify(token, this.secret);
+            console.log(payload)
             const parsed = TokenPayloadSchema.safeParse(payload);
             if (!parsed.success) return null;
             return parsed.data;

--- a/apps/backend/src/modules/auth/token.service.ts
+++ b/apps/backend/src/modules/auth/token.service.ts
@@ -38,7 +38,6 @@ export class TokenService {
     getTokenPayload(token: string) {
         try {
             const payload = jwt.verify(token, this.secret);
-            console.log(payload)
             const parsed = TokenPayloadSchema.safeParse(payload);
             if (!parsed.success) return null;
             return parsed.data;

--- a/apps/frontend/lib/auth.ts
+++ b/apps/frontend/lib/auth.ts
@@ -2,6 +2,22 @@ import NextAuth from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import { cookies } from "next/headers";
 
+function parseTokenExpiry(token: string): { maxAge: number; exp: number } {
+  try {
+    const payload = JSON.parse(
+      Buffer.from(token.split(".")[1], "base64url").toString()
+    );
+    if (payload.exp) {
+      const now = Math.floor(Date.now() / 1000);
+      return { maxAge: Math.max(0, payload.exp - now), exp: payload.exp };
+    }
+  } catch {
+    // fall through to default
+  }
+  const defaultMaxAge = 12 * 60 * 60;
+  return { maxAge: defaultMaxAge, exp: Math.floor(Date.now() / 1000) + defaultMaxAge };
+}
+
 export const { handlers, signIn, signOut, auth } = NextAuth({
   providers: [
     Credentials({
@@ -31,6 +47,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           // Propagate the mysagra_token cookie from the backend response to the browser.
           // The backend sets it via Set-Cookie header, but since this is a server-to-server
           // fetch, the cookie would otherwise be lost and never reach the user's browser.
+          let tokenExpiry: number | undefined;
+
           const setCookieHeader = response.headers.getSetCookie();
           if (setCookieHeader) {
             const cookieStore = await cookies();
@@ -43,12 +61,15 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
                   .slice(1)
                   .join("=");              // handle '=' in token value
 
+                const { maxAge, exp } = parseTokenExpiry(tokenValue);
+                tokenExpiry = exp;
+
                 cookieStore.set("mysagra_token", tokenValue, {
                   httpOnly: true,
                   secure: process.env.NODE_ENV === "production",
                   sameSite: "lax",
                   path: "/",
-                  maxAge: 6 * 60 * 60, // 6 hours — matches backend
+                  maxAge,
                 });
               }
             }
@@ -66,6 +87,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             name: data.username || (credentials.username as string),
             email: `${credentials.username}@myamministratore.local`,
             role,
+            tokenExpiry,
           };
         } catch (error) {
           return null;
@@ -80,6 +102,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           ...token,
           id: user.id,
           role: (user as any).role,
+          exp: (user as any).tokenExpiry ?? token.exp,
         };
       }
       return token;
@@ -97,7 +120,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   },
   session: {
     strategy: "jwt",
-    maxAge: 6 * 60 * 60, // 6 hours
+    maxAge: 12 * 60 * 60, // 12 hours — matches backend JWT expiry
   },
   secret: process.env.AUTH_SECRET,
   cookies: {
@@ -108,7 +131,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         sameSite: "lax",
         path: "/",
         secure: process.env.NODE_ENV === "production",
-        maxAge: 6 * 60 * 60, // 6 hours — matches session.maxAge
+        maxAge: 12 * 60 * 60, // 12 hours — matches session.maxAge
       },
     },
     callbackUrl: {


### PR DESCRIPTION
This pull request extends the authentication token and session expiry from 6 hours to 12 hours across both the backend and frontend. It also improves how the frontend parses and synchronizes token expiry, ensuring consistency between the backend JWT and frontend session handling.

**Backend expiry updates:**

* Increased JWT expiry from 6 hours to 12 hours in the `TokenService` (`apps/backend/src/modules/auth/token.service.ts`).
* Updated the `mysagra_token` cookie's `maxAge` to 12 hours in the `AuthController` (`apps/backend/src/modules/auth/auth.controller.ts`).

**Frontend expiry handling and synchronization:**

* Added a `parseTokenExpiry` function in `auth.ts` to extract the expiry from the JWT and use it for setting the cookie's `maxAge`, ensuring the frontend cookie matches the backend token's expiry (`apps/frontend/lib/auth.ts`). [[1]](diffhunk://#diff-eefee1362e3861ff48f31a7d4a3e048fac4a30fa81a0e0e66b0e0535240db717R5-R20) [[2]](diffhunk://#diff-eefee1362e3861ff48f31a7d4a3e048fac4a30fa81a0e0e66b0e0535240db717R64-R72)
* Updated the session and cookie `maxAge` values to 12 hours to match the backend, and propagated the token expiry throughout the authentication flow (`apps/frontend/lib/auth.ts`). [[1]](diffhunk://#diff-eefee1362e3861ff48f31a7d4a3e048fac4a30fa81a0e0e66b0e0535240db717L100-R123) [[2]](diffhunk://#diff-eefee1362e3861ff48f31a7d4a3e048fac4a30fa81a0e0e66b0e0535240db717L111-R134)
* Ensured the token expiry (`exp`) is included in the JWT and session objects for consistent expiry tracking on the frontend (`apps/frontend/lib/auth.ts`). [[1]](diffhunk://#diff-eefee1362e3861ff48f31a7d4a3e048fac4a30fa81a0e0e66b0e0535240db717R90) [[2]](diffhunk://#diff-eefee1362e3861ff48f31a7d4a3e048fac4a30fa81a0e0e66b0e0535240db717R105)